### PR TITLE
docs: document device filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,28 @@ export CLOUDFLARE_LIST_ID="your-cloudflare-list-id"
 
 ### Device Filtering
 
-- `include_tags`: Only sync devices with these tags (empty = all devices)
-- `exclude_tags`: Skip devices with these tags
-- Platform filtering: Automatically excludes iPhone and iPad devices
-- `blueprints_include` / `blueprints_exclude`: Filter devices by Kandji blueprint IDs or names
-- `sync_mobile_devices`: If true, syncs mobile devices (default: false)
+Use these settings to control which Kandji devices are synced:
+
+- `include_tags` / `exclude_tags`: Only sync devices with specific tags or skip those with excluded tags
+- `sync_devices_without_owners`: Include devices that have no assigned owner
+- `sync_mobile_devices`: Sync mobile devices (defaults to `false` to only sync computers)
+- `blueprints_include` / `blueprints_exclude`: Filter devices by blueprint IDs or names
+
+Example configuration:
+
+```yaml
+kandji:
+  include_tags: ["corp-managed"]
+  exclude_tags: ["do-not-sync"]
+  sync_devices_without_owners: true
+  sync_mobile_devices: false
+  blueprints_include:
+    blueprint_ids: ["abcd-1234"]
+    blueprint_names: ["Production"]
+  blueprints_exclude:
+    blueprint_ids: []
+    blueprint_names: ["Test"]
+```
 
 ### Performance Tuning
 


### PR DESCRIPTION
## Summary
- document filtering options for tags, owners, mobile devices and blueprints
- add config.yaml snippet demonstrating device filter configuration

## Testing
- ❌ `go test ./...` (module root)
- ✅ `go test ./...` (from src, no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c7dc4f376c8322909fbdb52e3bacc9