### PR TITLE
Prevent deletion of Kandji devices when merging source lists

### DIFF
--- a/src/syncer/syncer.go
+++ b/src/syncer/syncer.go
@@ -97,6 +97,7 @@ func (s *Syncer) Sync(ctx context.Context) {
 		}
 
 		filteredKandjiDevices = append(filteredKandjiDevices, device)
+		filteredKandjiSerials = append(filteredKandjiSerials, device.SerialNumber)
 		s.log.Debug("Including device for sync", "serial_number", device.SerialNumber)
 	}
 	s.log.Info("Total new devices in Kandji that pass filters", "count", len(filteredKandjiDevices))


### PR DESCRIPTION
## Summary
- Track serial numbers for Kandji devices passing filters
- Use these serials when building merged source serial set so OnMissing=delete keeps valid Kandji devices

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7dc7a56d88322869304eab1dcf4b9