### PR TITLE
Close Kandji response bodies explicitly

### DIFF
--- a/src/kandji/kandji.go
+++ b/src/kandji/kandji.go
@@ -186,16 +186,20 @@ func (c *Client) GetDevices(ctx context.Context) ([]Device, error) {
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
+			if resp != nil {
+				resp.Body.Close()
+			}
 			return nil, fmt.Errorf("failed to execute Kandji API request: %w", err)
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
 			return nil, fmt.Errorf("received non-200 status from Kandji API: %s, body: %s", resp.Status, string(body))
 		}
 
 		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read Kandji API response body: %w", err)
 		}


### PR DESCRIPTION
## Summary
- avoid accumulating defers in `GetDevices` by closing Kandji API responses immediately after use
- ensure response bodies are closed for error paths as well

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7dcfbebfc83229027ff5babecd855