### PR TITLE
Default log level to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ export KANDJI_API_TOKEN="your-kandji-api-token"
 export CLOUDFLARE_API_TOKEN="your-cloudflare-api-token"
 export CLOUDFLARE_ACCOUNT_ID="your-cloudflare-account-id"
 export CLOUDFLARE_LIST_ID="your-cloudflare-list-id"
+export LOG_LEVEL="info" # optional, defaults to "info"
 ```
 
 ## Cloudflare Setup
@@ -196,6 +197,8 @@ When combined with WARP clients:
 - `info`: General operational information
 - `warn`: Non-fatal issues
 - `error`: Error conditions
+
+The log level can be set via the `LOG_LEVEL` environment variable and defaults to `"info"`.
 
 ### Key Metrics
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -209,6 +209,11 @@ func ParseConfig() (*Config, error) {
 		cfg.Batch.MaxConcurrentBatches = *maxConcurrentBatches
 	}
 
+	// Set default log level if not specified
+	if cfg.Log.Level == "" {
+		cfg.Log.Level = "info"
+	}
+
 	// Set default sync interval if not specified
 	if cfg.SyncInterval == 0 {
 		cfg.SyncInterval = 5 * time.Minute
@@ -306,6 +311,11 @@ func LoadConfig() (*Config, error) {
 	}
 	if logLevel := os.Getenv("LOG_LEVEL"); logLevel != "" {
 		cfg.Log.Level = logLevel
+	}
+
+	// Set default log level if not specified
+	if cfg.Log.Level == "" {
+		cfg.Log.Level = "info"
 	}
 
 	// Set default sync interval if not specified


### PR DESCRIPTION
## Summary
- Default log level to "info" when unspecified in configuration parsing
- Document LOG_LEVEL environment variable and its "info" default

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7dcfa17e083229bbdc7873fe853bd